### PR TITLE
Fix the 'about' routing error

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -11,7 +11,7 @@
 <div class:dark>
   <main class="transition-all dark:bg-slate-900 dark:text-white">
     <NavBar
-      routes={{ "/": "Home", about: "About" }}
+      routes={{ "/": "Home", "/about": "About" }}
       useLightDark={true}
       bind:dark
     >


### PR DESCRIPTION
Routing to 'about' from while playing the game causes this error.

However, this is fixed.

P.S. If you want to add this repo to hacktoberfest, don't forget to add the 'hacktoberfest' topic to this repo

![image](https://user-images.githubusercontent.com/28824919/193317155-d89b2130-2f15-43a5-8538-344d5d9d6d2b.png)
